### PR TITLE
feat: add support for memory shapefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN go get github.com/evanoberholster/timezoneLookup
 RUN curl -LO https://github.com/evansiroky/timezone-boundary-builder/releases/download/2020d/timezones-with-oceans.geojson.zip
 RUN unzip timezones-with-oceans.geojson.zip 
 # build the database
-RUN go run /go/src/github.com/evanoberholster/timezoneLookup/cmd/timezone.go -json "/tz/combined-with-oceans.json" -db=/timezone -type=boltdb
+# build timezone.snap.db
+RUN go run go/src/github.com/evanoberholster/timezoneLookup/cmd/timezone.go -json "/tz/combined-with-oceans.json" -db=/timezone -type=boltdb
+# build timezone.snap.json
+RUN go run go/src/github.com/evanoberholster/timezoneLookup/cmd/timezone.go -json "/tz/combined-with-oceans.json" -db=/timezone -type=memory
 # checkout the project 
 WORKDIR /builder
 COPY . .
@@ -30,6 +33,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /geo2tz -ldflags="-s -w -e
 FROM scratch
 # Copy our static executable.
 COPY --from=builder /timezone.snap.db /
+COPY --from=builder /timezone.snap.json /
 COPY --from=builder /geo2tz /
 # Copy the temlates folder
 # COPY templates /templates

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ The image is built on [scratch](https://hub.docker.com/_/scratch), the image siz
 - ~11mb the application
 - ~62mb the tz data
 
+If you want to use the in memory shapefile (which is faster than the default boltDB):
+1. Crate a `config.yaml` file, with the following content:
+```
+tz:
+    database_type: memory
+    database_name: timezone
+    snappy: true
+    download_tz_data_url: https://api.github.com/repos/evansiroky/timezone-boundary-builder/releases/latest
+    download_tz_filename: timezones-with-oceans.geojson.zip
+```
+2. Bind the `config.yaml` to the docker image with the following command (note config file should be in the same dir where the docker command is executed, else change the path in the bind arg of the command):
+```sh
+sudo docker run -it --mount type=bind,source=`pwd`/config.yaml,target=/etc/geo2tz/config.yaml -p 2004:2004 noandrea/geo2tz
+```
+
 ## Docker compose
 
 Docker compose yaml example


### PR DESCRIPTION
Currently in the Docker image is packaged only the timezone.snap.db for the boltdb which is way slower than the memory option with timezone.snap.json, This PR packages the json shape file also which will make the image slightly bigger, but it is a small price to pay. This way we will be given the possibility to choose what shapefile to use by running the image with passing a config.yaml

docker command
```
sudo docker run -it --mount type=bind,source=`pwd`/config.yaml,target=/etc/geo2tz/config.yaml -p 2004:2004 noandrea/geo2tz
```
config.yaml (in same dir we run the docker command)
```
tz:
    database_type: memory
    database_name: timezone
    snappy: true
    download_tz_data_url: https://api.github.com/repos/evansiroky/timezone-boundary-builder/releases/latest
    download_tz_filename: timezones-with-oceans.geojson.zip
```